### PR TITLE
Add webpage for DogTreat Delight

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
 Saschy/Saschy is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+Visit our DogTreat Delight page at [index.html](index.html).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DogTreat Delight</title>
+    <style>
+        body { font-family: Arial, sans-serif; background-color: #f9f9f9; margin: 0; padding: 0; }
+        header { background-color: #ff8c00; color: white; padding: 20px; text-align: center; }
+        main { padding: 20px; }
+        .product { display: flex; flex-direction: column; align-items: center; margin-top: 20px; }
+        .product img { max-width: 300px; }
+        footer { background-color: #333; color: white; text-align: center; padding: 10px; margin-top: 40px; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>DogTreat Delight</h1>
+        <p>Delicious treats for your beloved canine!</p>
+    </header>
+    <main>
+        <section class="product">
+            <img src="https://placekitten.com/300/200" alt="Dog treats">
+            <h2>Our Signature Treats</h2>
+            <p>Made with natural ingredients and lots of love.</p>
+        </section>
+    </main>
+    <footer>
+        &copy; 2024 DogTreat Delight
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a simple webpage `index.html` showcasing DogTreat Delight, a dog treat brand
- update `README.md` with a link to the new page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684004948e08832cbdad579819195291